### PR TITLE
【Fix #21】ログイン分岐画面を作成

### DIFF
--- a/app/controllers/login_controller.rb
+++ b/app/controllers/login_controller.rb
@@ -1,0 +1,4 @@
+class LoginController < ApplicationController
+  def index
+  end
+end

--- a/app/views/login/index.html.erb
+++ b/app/views/login/index.html.erb
@@ -1,0 +1,19 @@
+<div class="text-center">
+  <h2 class="text-info my-5">学生医療管理プログラム</h2>
+
+  <div>
+    <%= link_to "学生アカウントでログイン",new_user_student_session_path,
+      class: "btn btn-info", style: "width:400px;"
+    %>
+  </div>
+
+  <div class="row mx-auto my-5 w-50">
+    <hr class="col"><span class="text-secondary mx-2">または</span><hr class="col">
+  </div>
+
+  <div>
+    <%= link_to "教員/医師アカウントでログイン", new_user_officer_session_path,
+      class: "btn btn-info", style: "width:400px;"
+    %>
+  </div>
+</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,7 @@ module MedicalMgtForStudents
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
     config.i18n.default_locale = :ja
+    config.autoload_paths += %W(#{config.root}/lib)
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -277,10 +277,11 @@ Devise.setup do |config|
   # If you want to use other strategies, that are not supported by Devise, or
   # change the failure app, you can configure them inside the config.warden block.
   #
-  # config.warden do |manager|
-  #   manager.intercept_401 = false
-  #   manager.default_strategies(scope: :user).unshift :some_external_strategy
-  # end
+  config.warden do |manager|
+    manager.failure_app = CustomAuthenticationFailure
+    # manager.intercept_401 = false
+    # manager.default_strategies(scope: :user).unshift :some_external_strategy
+  end
 
   # ==> Mountable engine configurations
   # When using Devise inside an engine, let's call it `MyEngine`, and this engine

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   root 'homes#index'
+  get 'login', to: 'login#index'
   resources :homes, :only => [:index]
   resources :contacts do
     resources :comments

--- a/lib/custom_authentication_failure.rb
+++ b/lib/custom_authentication_failure.rb
@@ -1,0 +1,6 @@
+class CustomAuthenticationFailure < Devise::FailureApp
+  protected
+  def redirect_url
+    login_path
+  end
+end


### PR DESCRIPTION
ログイン分岐画面を作成。
現在は設定されていないが、`authenticate_user_student`などログイン必須画面に飛んだ際のリダイレクト先として、このログイン画面を設定している。