### PR TITLE
【Fix #25】投稿公開機能を実装

### DIFF
--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -2,7 +2,11 @@ class ContactsController < ApplicationController
   before_action :set_contact, only: %i(show edit update destroy)
 
   def index
-    @contacts = Contact.all
+    if current_user_officer && current_user_officer.type == '医師'
+      @contacts = Contact.where(release: true)
+    else
+      @contacts = Contact.all
+    end
   end
 
   def new
@@ -44,7 +48,11 @@ class ContactsController < ApplicationController
   end
 
   def set_contact
-    @contact = Contact.find(params[:id])
+    if current_user_officer && current_user_officer.type == '医師'
+      @contact = Contact.where(release: true).find(params[:id])
+    else
+      @contact = Contact.find(params[:id])
+    end
   end
 
   def contact_params

--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -48,6 +48,6 @@ class ContactsController < ApplicationController
   end
 
   def contact_params
-    params.require(:contact).permit %i(title content image)
+    params.require(:contact).permit %i(title content image release)
   end
 end

--- a/app/views/contacts/_form.html.erb
+++ b/app/views/contacts/_form.html.erb
@@ -17,6 +17,16 @@
       <%= f.file_field :image, class: "image_form", style: "display: none;"%>
     </div>
 
+    <div class="form-group">
+      <div class="small form-text text-danger">
+        ※公開を選択すると医療関係者に情報が開示されます。
+      </div>
+      <div class="custom-switch">
+        <%= f.check_box :release, class: "custom-control-input" %>
+        <%= f.label :release, "公開しますか？", class: "custom-control-label" %>
+      </div>
+    </div>
+
     <div class="form-row">
       <div class="col">
         <%= f.submit "送信", class: "btn btn-info form-control" %>

--- a/app/views/contacts/show.html.erb
+++ b/app/views/contacts/show.html.erb
@@ -1,6 +1,6 @@
 <div class="card mx-auto" style="max-width:700px;">
   <div class="card-header alert-info">
-    <div style="font-size:0.7rem;" >
+    <div class="float-left" style="font-size:0.7rem;" >
       <% if @contact.user_student  %>
         <%= @contact.user_student.student_id %>
         <%= @contact.user_student.name %>
@@ -9,6 +9,14 @@
       <% end %>
       <%= @contact.created_at %>
     </div>
+    <div class="float-right">
+      <% if @contact.release %>
+        <strong class="text-danger border border-danger p-1">公開中</strong>
+      <% elsif %>
+        <strong class="border border-info p-1">非公開</strong>
+      <% end %>
+    </div>
+    <br>
     <div class="text-center my-3">
       <strong><%= @contact.title %></strong>
     </div>

--- a/db/migrate/20200818012840_add_release_to_contacts.rb
+++ b/db/migrate/20200818012840_add_release_to_contacts.rb
@@ -1,0 +1,5 @@
+class AddReleaseToContacts < ActiveRecord::Migration[5.2]
+  def change
+    add_column :contacts, :release, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_11_023926) do
+ActiveRecord::Schema.define(version: 2020_08_18_012840) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -73,6 +73,7 @@ ActiveRecord::Schema.define(version: 2020_08_11_023926) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_officer_id"
+    t.boolean "release", default: false, null: false
     t.index ["user_officer_id"], name: "index_contacts_on_user_officer_id"
     t.index ["user_student_id"], name: "index_contacts_on_user_student_id"
   end


### PR DESCRIPTION
#25 

**投稿の公開・非公開を選択できる機能を実装**
- 投稿作成者は、新規作成時にその投稿を公開するか否かを選べる。
- 編集で公開・非公開を変更できる。
- 医師側ユーザは公開された記事のみ閲覧可。