### PR TITLE
【Fix #29】user_officerがホームに入れるよう設定

### DIFF
--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -1,6 +1,16 @@
 class HomesController < ApplicationController
-  before_action :authenticate_user_student!, only: %i[index]
-  before_action :authenticate_user_student!, only: %i[index]
+  before_action :authenticate!, only: %i[index]
+
   def index
+  end
+
+  private
+
+  def authenticate!
+    if user_officer_signed_in?
+      authenticate_user_officer!
+    else
+      authenticate_user_student!
+    end
   end
 end

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -53,7 +53,9 @@
       <p class="card-text">
         プロフィールページです🙍‍♂️🙎‍♀️<br>※過去の自分の投稿や自分に向けられたコメントの一覧が確認できます。
       </p>
-      <%= link_to "プロフィール" ,user_student_path(current_user_student.id), class: "text-white form-control btn btn-warning" %>
+      <% if current_user_student %>
+        <%= link_to "プロフィール" ,user_student_path(current_user_student.id), class: "text-white form-control btn btn-warning" %>
+      <% end %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
### user_officerがログイン後もhomeに入れないバグを修正
#29

**コントローラの修正** 
```
# homes_controller.rb
class HomesController < ApplicationController
  before_action :authenticate!, only: %i[index]

  # 省略

  private
  def authenticate!
    if user_officer_signed_in?
      authenticate_user_officer!
    else
      authenticate_user_student!
    end
  end
end
```

**この変更に伴うindexの修正**
officerはstudent_idがないので条件で分ける記述を追加
```
# index.html.erb
<% if current_user_student %>
  <%= link_to "プロフィール" ,user_student_path(current_user_student.id), class: "text-white form-control btn btn-warning" %>
<% end %>
```
