### PR TITLE
【Fix #34】未ログインでcontactページに入れないよう修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,14 @@ class ApplicationController < ActionController::Base
     current_user_student || current_user_officer
   end
 
+  def authenticate!
+    if user_officer_signed_in?
+      authenticate_user_officer!
+    else
+      authenticate_user_student!
+    end
+  end
+
   protected
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name,

--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -1,4 +1,5 @@
 class ContactsController < ApplicationController
+  before_action :authenticate!
   before_action :set_contact, only: %i(show edit update destroy)
 
   def index

--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -3,14 +3,4 @@ class HomesController < ApplicationController
 
   def index
   end
-
-  private
-
-  def authenticate!
-    if user_officer_signed_in?
-      authenticate_user_officer!
-    else
-      authenticate_user_student!
-    end
-  end
 end


### PR DESCRIPTION
#34 

`contacts_controller.rb`内にも以下設定
```
before_action :authenticate!
```
なお、authenticate!メソッドは、controller全般で使えるよう`application_controller.rb`内に移動させている。